### PR TITLE
Add Smithery.ai deployment support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "type": "module",
   "main": "dist/plantuml-mcp-server.js",
+  "module": "src/plantuml-mcp-server.ts",
   "bin": {
     "plantuml-mcp-server": "dist/plantuml-mcp-server.js"
   },
@@ -26,7 +27,9 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/plantuml-mcp-server.js",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "smithery:build": "npx @smithery/cli build",
+    "smithery:dev": "npx @smithery/cli dev"
   },
   "keywords": [
     "mcp",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,1 @@
+runtime: "typescript"

--- a/src/plantuml-mcp-server.ts
+++ b/src/plantuml-mcp-server.ts
@@ -401,7 +401,25 @@ return result; // Success
     await this.server.connect(transport);
     console.error('PlantUML MCP server running on stdio');
   }
+
+  getServer() {
+    return this.server;
+  }
 }
 
-const server = new PlantUMLMCPServer();
-server.run().catch(console.error);
+// Export createServer function for Smithery.ai
+export default function createServer({ config }: { config?: { plantumlServerUrl?: string } } = {}) {
+  // Set environment variable if provided in config
+  if (config?.plantumlServerUrl) {
+    process.env.PLANTUML_SERVER_URL = config.plantumlServerUrl;
+  }
+
+  const mcpServer = new PlantUMLMCPServer();
+  return mcpServer.getServer();
+}
+
+// CLI execution for backward compatibility
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const server = new PlantUMLMCPServer();
+  server.run().catch(console.error);
+}


### PR DESCRIPTION
Enable deployment on Smithery.ai platform with minimal changes while preserving all existing CLI functionality for Claude Code/Desktop users.

**Changes:**
- Add smithery.yaml configuration
- Add module field and smithery scripts to package.json  
- Export createServer function for Smithery compatibility
- Maintain backward compatibility for existing users

**Testing:**
- ✅ CLI functionality verified unchanged
- ✅ Build process works
- ✅ Local Claude Code testing successful

**Implementation Details:**
- Minimal code changes (~15 lines total across all files)
- Dual deployment: CLI package + Smithery platform
- Zero breaking changes for current users